### PR TITLE
Skip auth

### DIFF
--- a/bin/mongolly
+++ b/bin/mongolly
@@ -70,7 +70,7 @@ module Mongolly
     end
 
     def valid_config?
-      %w(database db_username db_password access_key_id secret_access_key).each do |arg|
+      %w(database access_key_id secret_access_key).each do |arg|
         raise ArgumentError.new("#{arg} cannot be empty") if @config[arg.to_sym].to_s.strip.empty?
       end
       return true

--- a/lib/mongolly/shepherd.rb
+++ b/lib/mongolly/shepherd.rb
@@ -54,7 +54,7 @@ module Mongolly
         @logger.debug "connecting to a single instance #{@database}"
         Mongo::MongoClient.new(*@database.split(':'))
       end
-      db['admin'].authenticate(@db_username, @db_password)
+      db['admin'].authenticate(@db_username, @db_password) if @db_username && @db_password
       return db
     end
   end


### PR DESCRIPTION
mongolly appears to require auth for mongo. this makes the db auth conditional and also removes them from the validation check.
