### PR TITLE
Custom tag support for snapshots

### DIFF
--- a/lib/mongolly/extensions/mongo/mongo_client.rb
+++ b/lib/mongolly/extensions/mongo/mongo_client.rb
@@ -60,6 +60,7 @@ protected
           snapshot = volume.create_snapshot("#{options[:backup_key]} #{Time.now} mongolly #{host}")
           snapshot.add_tag('created_at', value: Time.now)
           snapshot.add_tag('backup_key', value: options[:backup_key])
+          snapshot.add_tag(options[:custom_tag_key], value: options[:custom_tag_value] || 1) if options[:custom_tag_key]
         end
       end
     end

--- a/lib/mongolly/shepherd.rb
+++ b/lib/mongolly/shepherd.rb
@@ -37,9 +37,11 @@ module Mongolly
       @logger.debug "deleting snapshots older than #{age}}"
       ec2.snapshots.with_owner(:self).each do |snapshot|
         unless snapshot.tags[:created_at].nil? || snapshot.tags[:backup_key].nil?
-          if Time.parse(snapshot.tags[:created_at]) < age
-            @logger.debug "deleting snapshot #{snapshot.id} tagged #{snapshot.tags[:backup_key]} created at #{snapshot.tags[:created_at]}, earlier than #{age}"
-            snapshot.delete  unless @dry_run
+          if @options[:custom_tag_key] && snapshot.tags[@options[:custom_tag_key]] == (@options[:custom_tag_value] || 1)
+            if Time.parse(snapshot.tags[:created_at]) < age
+              @logger.debug "deleting snapshot #{snapshot.id} tagged #{snapshot.tags[:backup_key]} created at #{snapshot.tags[:created_at]}, earlier than #{age}"
+              snapshot.delete  unless @dry_run
+            end
           end
         end
       end

--- a/lib/mongolly/shepherd.rb
+++ b/lib/mongolly/shepherd.rb
@@ -37,7 +37,7 @@ module Mongolly
       @logger.debug "deleting snapshots older than #{age}}"
       ec2.snapshots.with_owner(:self).each do |snapshot|
         unless snapshot.tags[:created_at].nil? || snapshot.tags[:backup_key].nil?
-          if @options[:custom_tag_key] && snapshot.tags[@options[:custom_tag_key]] == (@options[:custom_tag_value] || 1)
+          if @options[:custom_tag_key].nil? || @options[:custom_tag_key] && snapshot.tags[@options[:custom_tag_key]] == (@options[:custom_tag_value] || 1)
             if Time.parse(snapshot.tags[:created_at]) < age
               @logger.debug "deleting snapshot #{snapshot.id} tagged #{snapshot.tags[:backup_key]} created at #{snapshot.tags[:created_at]}, earlier than #{age}"
               snapshot.delete  unless @dry_run


### PR DESCRIPTION
Make it possible to add custom tag for snapshots for better filtering and to be able to manage different setups of mongo in one AWS account (for example allow different periods for cleanup).
