### PR TITLE
Fix time parsing for the age argument.

### DIFF
--- a/bin/mongolly
+++ b/bin/mongolly
@@ -18,7 +18,7 @@ module Mongolly
     method_option :age, aliases: "-a", required: true
     method_option :dry_run, type: :boolean, desc: "Step through command without changes"
     def clean
-      age = Time.parse.utc(options[:age])
+      age = Time.parse(options[:age]).utc
       Shepherd.new({ dry_run: options[:dry_run] }.merge(config)).cleanup(age)
     end
 


### PR DESCRIPTION
**Before:**
```
irb(main):009:0> Time.parse.utc("2017-07-12")
ArgumentError: wrong number of arguments (0 for 1..2)
	from /Users/hawker/.rbenv/versions/2.2.4/lib/ruby/2.2.0/time.rb:359:in `parse'
	from (irb):9
	from /Users/hawker/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-3.2.22.4/lib/rails/commands/console.rb:47:in `start'
	from /Users/hawker/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-3.2.22.4/lib/rails/commands/console.rb:8:in `start'
	from /Users/hawker/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-3.2.22.4/lib/rails/commands.rb:41:in `<top (required)>'
	from ./script/rails:7:in `require'
	from ./script/rails:7:in `<main>'
```

**After**
```
irb(main):005:0> Time.parse("2017-07-12").utc
=> 2017-07-12 07:00:00 UTC
```

Traceback:

```
$ mongolly clean -a 2017-07-12
/var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/2.2.0/time.rb:359:in `parse': wrong number of arguments (0 for 1..2) (ArgumentError)
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/mongolly-0.2.11/bin/mongolly:21:in `clean'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/mongolly-0.2.11/bin/mongolly:85:in `<top (required)>'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/bin/mongolly:23:in `load'
	from /var/lib/jenkins/jenkins-data/.rbenv/versions/2.2.4/bin/mongolly:23:in `<main>'
```